### PR TITLE
MongoMapper 0.9.0 updates

### DIFF
--- a/devise-mongo_mapper.gemspec
+++ b/devise-mongo_mapper.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name          = 'devise-mongo_mapper'
-  s.version       = '0.0.1'
+  s.version       = '0.0.2'
   s.platform      = Gem::Platform::RUBY
   s.authors       = ['Brandon Keepers']
   s.email         = ['brandon@collectiveidea.com']

--- a/lib/devise/orm/mongo_mapper.rb
+++ b/lib/devise/orm/mongo_mapper.rb
@@ -25,6 +25,8 @@ end
 
 module MongoMapper
   module Devise
+    extend ActiveSupport::Concern
+
     module ClassMethods
       include ::Devise::Models
       include ::Devise::Orm::MongoMapper::Hook


### PR DESCRIPTION
From 0.9.0 version of MongoMapper plugins must extend ActiveSupport::Concern
